### PR TITLE
[IMP] open_academy: Create domains to limit visible instructors in the instructor field of session T#52900

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -29,5 +29,6 @@
 
     'demo': [
         "demo/course.xml",
+        "demo/category.xml",
     ],
 }

--- a/open_academy/demo/category.xml
+++ b/open_academy/demo/category.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="partner_category_teacher_level_1" model="res.partner.category">
+        <field name="name">Teacher / Level 1</field>
+    </record>
+
+    <record id="partner_category_teacher_level_2" model="res.partner.category">
+        <field name="name">Teacher / Level 2</field>
+    </record>
+</odoo>

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -9,6 +9,6 @@ class Session(models.Model):
     start_date = fields.Datetime()
     duration = fields.Float()
     number_of_seats = fields.Integer()
-    instructor_id = fields.Many2one("res.partner")
+    instructor_id = fields.Many2one("res.partner", domain="['|',('is_instructor','=',True),('category_id.name','like','Teacher')]")
     course_id = fields.Many2one("course", required=True)
     attendee_ids = fields.Many2many("res.partner")

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -12,7 +12,7 @@
                         <field name="start_date"/>
                         <field name="duration"/>
                         <field name="number_of_seats"/>
-                        <field name="instructor_id" domain="[('is_instructor','=',True)]"/>
+                        <field name="instructor_id"/>
                         <field name="course_id"/>
                         <field name="attendee_ids"/>
                     </group>


### PR DESCRIPTION
Create user with is_instructor set True
![Screenshot_20220113_123851](https://user-images.githubusercontent.com/78433819/149389653-11227c71-cf9d-4086-a3e9-a8ca27ce15b3.png)


Domain to is_instructor set True
![Screenshot_20220112_134243](https://user-images.githubusercontent.com/78433819/149265920-30936fe5-ff18-4966-8078-344a7805c2a9.png)


Create tags
![Screenshot_20220113_123458](https://user-images.githubusercontent.com/78433819/149389188-e6689609-41f5-4820-86af-25e7b494a524.png)

Create users with above tags
![Screenshot_20220113_123345](https://user-images.githubusercontent.com/78433819/149389429-162b4cab-ae2f-4bdb-8a87-96730c41c706.png)


Domain with two limits: is_insnsstructor set True and tags: "Teacher / Level 1" and "Teacher / Level 2"
![Screenshot_20220113_123405](https://user-images.githubusercontent.com/78433819/149389317-ee7c60ba-8301-4d5e-9c48-45c2517b28b6.png)


